### PR TITLE
Dynamic addresses & broadcast support (#8)

### DIFF
--- a/protocol-implementation/C/src/serial_protocol.c
+++ b/protocol-implementation/C/src/serial_protocol.c
@@ -5,6 +5,8 @@
 uint32_t _parsing_index = 0;
 uint32_t _current_message_len = 0;
 uint8_t _current_message[RX_BUFFER_LEN];
+uint8_t _my_addr = 0;
+uint8_t _broadcast_addr = 0xFF;
 
 void _queue_byte(uint8_t byte)
 {
@@ -60,7 +62,7 @@ void _parse_input(uint8_t input)
 
                 // If the CRC is valid, and the message is meant for us, recieve the message!
                 uint8_t tgt_addr = _current_message[TGT_ADDR_POS];
-                if (crc == calculated_crc && tgt_addr == MY_ADDR)
+                if (crc == calculated_crc && (tgt_addr == _my_addr || tgt_addr == _broadcast_addr))
                 {
                     user_rcv_message(_current_message, total_len);
                     _reset_parsing_state();
@@ -113,6 +115,16 @@ void _parse_input(uint8_t input)
     }
 }
 
+void set_my_addr(uint8_t addr)
+{
+    _my_addr = addr;
+}
+
+void set_broadcast_addr(uint8_t addr)
+{
+    _broadcast_addr = addr;
+}
+
 void parse_input_buffer(uint8_t *input_buffer, uint32_t max_length)
 {
     for (uint32_t i = 0; i < max_length; i++)
@@ -131,7 +143,7 @@ int send_message(uint8_t dest_addr, uint8_t type, uint8_t *payload, uint32_t pay
     tx_buff[HEADER_0_POS] = HEADER_0_VAL;
     tx_buff[HEADER_1_POS] = HEADER_1_VAL;
     tx_buff[HEADER_2_POS] = HEADER_2_VAL;
-    tx_buff[SRC_ADDR_POS] = MY_ADDR;
+    tx_buff[SRC_ADDR_POS] = _my_addr;
     tx_buff[TGT_ADDR_POS] = dest_addr;
     tx_buff[MSG_TYPE_POS] = type;
     tx_buff[PAYLOAD_LEN_MSB_POS] = (uint8_t)((payload_length >> 8) & 0xFF);

--- a/protocol-implementation/C/src/serial_protocol.h
+++ b/protocol-implementation/C/src/serial_protocol.h
@@ -52,21 +52,16 @@ extern "C"
 #define NUM_OVER_HEAD_BYTES 10
 #define RX_BUFFER_LEN ((MAX_PAYLOAD_LEN + NUM_OVER_HEAD_BYTES) * 2)
 
-// Device address - you need to override this in your implementation.
-#define MY_ADDR 0x00
-
-// If this device is the host on the bus this is where you can implement periphal functionality.
-//#define PERIPHERAL_ADDR_0 0x01
-//#define PERIPHERAL_ADDR_1 0x02
-
 // Protocol version
-#define PROTOCOL_VERSION 0x0001
+#define PROTOCOL_VERSION 0x0002
 
 // Error codes
 #define SP_OK 0
 #define SP_ERR_ILLEGAL_MSG_LEN -1
 #define SP_ERR_NULL_PAYLOAD -2
 
+    void set_my_addr(uint8_t addr);
+    void set_broadcast_addr(uint8_t addr);
     void parse_input_buffer(uint8_t *input_buffer, uint32_t max_length);
     int send_message(uint8_t dest_addr, uint8_t type, uint8_t *payload, uint32_t payload_length);
 

--- a/protocol-implementation/Python/protocol.py
+++ b/protocol-implementation/Python/protocol.py
@@ -29,6 +29,7 @@ HEADER_BYTE2 = 0xFF
 
 # User address, you can change this to whatever you want
 my_addr = 0x01
+broadcast_addr = 0xFF
 
 # Maximum allowable length, you can change this - there is a maximum value of 65535 bytes
 MAX_MSG_LEN = 65535
@@ -186,7 +187,7 @@ def parse_byte(byte):
         # Check the CRC
         global my_addr
         if current_msg.msg_crc == calculate_crc(
-                current_msg) and current_msg.tgt_addr == my_addr:
+                current_msg) and (current_msg.tgt_addr == my_addr or current_msg.tgt_addr == broadcast_addr):
             # CRC is good, send the message to the message handler
             notify_parsed_message(current_msg)
             reset_parsing_state()

--- a/protocol-implementation/Python/protocol_tests.py
+++ b/protocol-implementation/Python/protocol_tests.py
@@ -4,10 +4,10 @@ from random import randint
 
 
 # Helper function to generate a random message
-def generate_random_message(length=-1):
+def generate_random_message(length=-1, addr=prot.my_addr):
     # Make a random message
     m_type = randint(0, 255)
-    t_addr = prot.my_addr
+    t_addr = addr
     if length == -1:
         length = randint(0, prot.MAX_MSG_LEN)
     m_payload = [randint(0, 255) for i in range(length)]
@@ -203,8 +203,7 @@ class TestParser(unittest.TestCase):
 
     # Test the parser function with a message that is not for me
     def test_invalid_msg_not_for_me(self):
-        msg = generate_random_message(0)
-        msg[4] = prot.my_addr + 1
+        msg = generate_random_message(0,prot.my_addr + 1)
         prot.parse_input_buffer(msg)
 
         # Get the parsed messages
@@ -248,8 +247,7 @@ class TestParser(unittest.TestCase):
 
     # Test the parser with back to back valid messages, one for me and one not
     def test_valid_msg_back_to_back_not_for_me(self):
-        msg = generate_random_message()
-        msg[4] = prot.my_addr + 1
+        msg = generate_random_message(-1, prot.my_addr + 1)
         prot.parse_input_buffer(msg)
 
         msg1 = generate_random_message()
@@ -270,6 +268,25 @@ class TestParser(unittest.TestCase):
         for i in range(msg_len):
             self.assertEqual(msg1[8 + i], msg_list[0].msg_payload[i])
 
+    # Test the parser for a broadcasted message
+    def test_valid_msg_broadcast(self):
+        msg = generate_random_message(-1, prot.broadcast_addr)
+        prot.parse_input_buffer(msg)
+
+        # Get the parsed messages
+        msg_list = prot.check_for_parsed_messages()
+
+        # Assert that the message is parsed properly
+        self.assertEqual(1, len(msg_list))
+        self.assertEqual(msg[3], msg_list[0].src_addr)
+        self.assertEqual(msg[4], msg_list[0].tgt_addr)
+        self.assertEqual(msg[5], msg_list[0].msg_type)
+
+        msg_len = msg[6] << 8 | msg[7]
+        self.assertEqual(msg_len, msg_list[0].msg_len)
+
+        for i in range(msg_len):
+            self.assertEqual(msg[8 + i], msg_list[0].msg_payload[i])
 
 if __name__ == '__main__':
     unittest.main()

--- a/utilities/serial-tester/.example_tester_config.json
+++ b/utilities/serial-tester/.example_tester_config.json
@@ -5,7 +5,8 @@
     },
     "tester_config": {
         "my_address": "0x01",
-        "target_address": "0x1a"
+        "target_address": "0x1a",
+        "broadcast_address": "0xFF"
     },
     "message_config": {
         "message_type": "0x0",
@@ -15,7 +16,7 @@
         "message_type": "0x00",
         "message_payload": [
             "0x00",
-            "0x01"
+            "0x02"
         ]
     },
     "command_response_config": {
@@ -26,7 +27,7 @@
                 "command_payload": [],
                 "response_payload": [
                     "0x00",
-                    "0x01"
+                    "0x02"
                 ]
             },
             {
@@ -61,6 +62,12 @@
                     "0x01",
                     "0x01"
                 ]
+            },
+            {
+                "command_type": "0x05",
+                "response_type": "0x01",
+                "command_payload": [],
+                "response_payload": []
             }
         ]
     }


### PR DESCRIPTION
* Added the broadcast address to the C and python implementation. Covered broadcast reception in unit tests

* Updated the C implementation with the ability to dynamically set its own address and the broadcast address. Did the same for the python implementation. Updated the unit tests and the serial tester program to support broadcast mode.